### PR TITLE
Upgrade to Crystal 0.12.0 (YAML.parse)

### DIFF
--- a/src/guardian.cr
+++ b/src/guardian.cr
@@ -29,7 +29,7 @@ module Guardian
       @watchers = [] of WatcherYML
 
       if File.exists? file
-        YAML.load_all(File.read(file)).each do |yaml|
+        YAML.parse_all(File.read(file)).each do |yaml|
           @watchers << WatcherYML.from_yaml(yaml.to_yaml)
         end
       else


### PR DESCRIPTION
Breaking change on Crystal 0.12.0 (2016-02-16):

> YAML.load was renamed to YAML.parse, and it now returns a YAML::Any.

```
$ crystal build src/guardian.cr --release
Error in ./src/guardian.cr:167: instantiating 'Guardian::Watcher:Class#new()'

Guardian::Watcher.new
                  ^~~

instantiating 'Guardian::Watcher#initialize()'

in ./src/guardian.cr:32: undefined method 'load_all' for YAML:Module

        YAML.load_all(File.read(file)).each do |yaml|
             ^~~~~~~~
```
