### PR TITLE
Uses crystal compile instead of build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ brew install guardian
 
 ```bash
 git clone https://github.com/f/guardian.git && cd guardian
-crystal build src/guardian.cr --release
+crystal compile src/guardian.cr --release
 ```
 
 ## Quickstart
@@ -62,7 +62,7 @@ Simply it has **YAML documents** with seperated by `---` line and each document 
 
 ```yaml
 files: ./**/*.cr
-run: crystal build ./src/guardian.cr
+run: crystal compile ./src/guardian.cr
 ---
 files: ./shard.yml
 run: crystal deps

--- a/src/guardian/watcher.cr
+++ b/src/guardian/watcher.cr
@@ -146,7 +146,7 @@ module Guardian
         puts "Created #{".guardian.yml".colorize(:green)} of #{file.colorize(:green)}"
         File.write "./.guardian.yml", <<-YAML
 files: ./**/*.cr
-run: crystal build #{file}
+run: crystal compile #{file}
 ---
 files: ./shard.yml
 run: crystal deps


### PR DESCRIPTION
Uses `crystal compile` instead of `crystal build` because it is deprecated.
