### PR TITLE
Update to use crystal 0.31.1

### DIFF
--- a/.guardian.yml
+++ b/.guardian.yml
@@ -2,4 +2,4 @@ files: ./**/*.cr
 run: crystal build ./src/guardian.cr
 ---
 files: ./shard.yml
-run: crystal deps
+run: shards install

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ files: ./**/*.cr
 run: crystal build ./src/guardian.cr
 ---
 files: ./shard.yml
-run: crystal deps
+run: shards install
 ```
 
 ### `%file%` Variable

--- a/shard.yml
+++ b/shard.yml
@@ -9,4 +9,6 @@ targets:
   guardian:
     main: src/guardian.cr
 
+crystal: 0.31.1
+
 license: MIT

--- a/src/guardian.cr
+++ b/src/guardian.cr
@@ -9,7 +9,7 @@ when "init"
   Guardian::Generator.new.generate
   exit
 else
-  OptionParser.parse! do |options|
+  OptionParser.parse do |options|
     options.on "-i", "--init", "Generates the .guardian.yml file" do
       Guardian::Generator.new.generate
       exit

--- a/src/guardian/generator.cr
+++ b/src/guardian/generator.cr
@@ -24,7 +24,7 @@ files: ./**/*.cr
 run: crystal build #{file}
 ---
 files: ./shard.yml
-run: crystal deps
+run: shards install
 YAML
       else
         puts "Created #{".guardian.yml".colorize(:green)}"


### PR DESCRIPTION
## Summary of the changes
* Initialize .guardian.yml with `shards install` rather than `crystal deps` - the latter was removed a few versions ago
* Invoke `OptionParser.parse` rather than  `OptionParser.parse!`, as the latter has been deprecated and throws a warning at compile time
* Include `crystal` field in shard.yml to indicate "the last known Crystal version that is capable to compile the Shard", as per the [shards spec](https://github.com/crystal-lang/shards/blob/master/SPEC.md)

## Testing
* I verified that the code still compiles fine when running `crystal build src/guardian.cr --release`
* I tested the newly built `guardian` on a crystal project and verified that `guardian --init` produces the expected output.