### PR TITLE
First step to parallelism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /libs/
 /.crystal/
 /.shards/
-guardian
+/bin/guardian
 
 
 # Libraries don't need dependency lock

--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ run: shards install
 
 ### `%file%` Variable
 
-Guardian replaces `%file%` variable in commands with the changed file.
+Guardian replaces `%file%` variable in commands with the changed file(s).
 
 ```yaml
 files: ./**/*.txt
 run: echo "%file% is changed"
 ```
 
-Think you have a `hello.txt` in your directory, and Guardian will run `echo "hello.txt is changed"` command when it's changed.
+Think you have a `hello.txt` & `goodbye.txt` in your directory, and Guardian will run `echo "hello.txt goodbye.txt is changed"` command when it's changed.
 
 ## Running Guardian
 

--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,11 @@ targets:
   guardian:
     main: src/guardian.cr
 
+dependencies:
+  pty:
+    github: crystal-posix/pty.cr
+    branch: main
+
 crystal: 0.35.1
 
 license: MIT

--- a/src/guardian.cr
+++ b/src/guardian.cr
@@ -4,6 +4,7 @@ require "colorize"
 
 ignore_executables = true
 clear_on_action = false
+verbose = 0
 case ARGV[0]?
 when "init"
   puts "\"init\" has been deprecated please use: -i or --init"
@@ -38,6 +39,10 @@ else
       clear_on_action = true
     end
 
+    options.on "--verbose", "More logging" do
+      verbose += 1
+    end
+
     options.invalid_option do
       puts options
       exit
@@ -45,4 +50,13 @@ else
   end
 end
 
-Guardian::Watcher.new ignore_executables, clear_on_action
+watcher = Guardian::Watcher.new ignore_executables, verbose, clear_on_action
+Signal::HUP.trap { watcher.shutdown }
+Signal::QUIT.trap { watcher.shutdown }
+Signal::TERM.trap { watcher.shutdown }
+begin
+  watcher.run
+ensure
+  watcher.close
+  # puts Dir.glob("/tmp/guardian*")
+end

--- a/src/guardian/command_run.cr
+++ b/src/guardian/command_run.cr
@@ -1,0 +1,90 @@
+require "pty/process"
+
+module Guardian
+  class CommandRun
+    # Only used with %file% substitution
+    enum MissingFiles
+      # (default) Removes missing files from the command args
+      # Suitable for use with `crystal spec`
+      Remove
+      # Keep missing files as command arguments
+      Preserve
+      # Skip running the command when any files are missing
+      SkipCommand
+      # Remove all %file% args from command
+      # Suitable for use with `crystal spec`
+      StripArgs
+    end
+
+    private FILE_NULL = File.new(File::NULL, "r")
+
+    private getter? has_command_substitution : Bool
+    @process_output = Pty::Process.new
+    @temp_file : File = File.tempfile("guardian", ".out")
+
+    @modified_files = Set(String).new
+
+    def initialize(@raw_command : String, missing_files : String)
+      @missing_files = MissingFiles.parse(missing_files)
+      @has_command_substitution = /%file%/ === @raw_command
+    end
+
+    def enqueue(file) : Nil
+      @modified_files << file
+    end
+
+    # returns true(success), false(failure)
+    def run : Bool
+      cmd = command
+      return true unless command
+
+      win_size = Pty.tty_win_size
+      win_size = {win_size[0 - 2], win_size[1]} if win_size
+
+      @temp_file.truncate 0
+      _, status = @process_output.run(command.not_nil!, input: FILE_NULL, shell: true, win_size: win_size) do |_, _, outputerr|
+        IO.copy outputerr, @temp_file
+        nil
+      end
+
+      if status.success?
+        STDOUT.puts "#{"✔".colorize(:green)} #{"$".colorize(:dark_gray)} #{cmd.colorize(:cyan)}"
+      else
+        STDOUT.puts "#{"✖".colorize(:red)} #{"$".colorize(:dark_gray)} #{cmd.colorize(:cyan)}"
+        @temp_file.rewind
+        @temp_file.each_line do |line|
+          puts "  #{line.gsub(/\n$/, "").colorize(:dark_gray)}"
+        end
+      end
+
+      status.success?
+    ensure
+      @modified_files.clear
+    end
+
+    def close
+      @process_output.signal? Signal::TERM
+      @temp_file.close
+      @temp_file.delete rescue nil
+    end
+
+    private def command : String?
+      if has_command_substitution?
+        existing_files = @modified_files.select { |file|
+          File.exists?(file)
+        }.to_a
+        if existing_files.size == @modified_files.size || @missing_files.remove?
+          @raw_command.gsub(/%file%/, existing_files.join(" "))
+        elsif @missing_files.strip_args?
+          @raw_command
+        elsif @missing_files.skip_command?
+          nil
+        else
+          raise "unsupported missing_files value #{@missing_files.inspect}"
+        end
+      else
+        @raw_command
+      end
+    end
+  end
+end


### PR DESCRIPTION
Commands are redirected to a file instead of buffered in memory
  Allows running commands with large output

Commands run with their own resized pty
  Preserves colors when outputting to a file
  Fixes command formatting when indenting 2 spaces

Queue tasks instead of running immediately (also necessary for future parallelism)
  Possibly fixes #14

Use `Set` to avoid infinite adding to @files/@runners when files created/deleted

Allow configurable behavior of how to handle missing files
  Defaults to remove missing files from command args
    Possibly fixes #4

Run single command with `cmd file1 file2` instead of 1 command per file

Output has changed
  Hide successful command output
  Show error output

--verbose option

Fix gitignore